### PR TITLE
Added Identifiable Conformance

### DIFF
--- a/Sources/WPSwift/Models/Post.swift
+++ b/Sources/WPSwift/Models/Post.swift
@@ -17,7 +17,7 @@ public enum CommentStatus: String, Codable, Sendable {
     }
 }
 
-public struct Post: Decodable, Sendable {
+public struct Post: Identifiable, Decodable, Sendable {
     public let id: Int
     public let date: Date?
     public let modified: Date?


### PR DESCRIPTION
It was driving me nuts that Post does not conform to identifiable despite meeting the requirements, making it impossible to use list(posts) { post in or sheet(item: post) without a bunch of workarounds.

One line one item change